### PR TITLE
avoid extraneous returned list

### DIFF
--- a/fizzBuzz.py
+++ b/fizzBuzz.py
@@ -1,1 +1,1 @@
-[print("Fizz"*(i%3==0)+"Buzz"*(i%5==0) or i) for i in range(1, 21)]
+print(*('Fizz'*(i%3==0) + 'Buzz'*(i%5==0) or i for i in range(1, 21)), sep='\n')


### PR DESCRIPTION
The original version prints the desired values as a side effect of the list comprehension, and then produces an extraneous list of None values as the actual returned object.

This version does away with that extraneous returned object, and prints the values purposefully rather than as a side effect.